### PR TITLE
Initialize Vee skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# CodexTest
+# Vee - Go to Market Platform
+
+This repository contains a minimal FastAPI skeleton for **Vee**, an AI‑native platform designed to unify and automate product, marketing and sales execution.
+
+The current implementation provides placeholder endpoints for the main modules:
+
+- **Product Marketing** (`/marketing`)
+- **Sales Enablement** (`/sales`)
+- **Product Management** (`/product`)
+
+Run the application locally:
+
+```bash
+pip install -r requirements.txt
+uvicorn vee.main:app --reload
+```
+
+Visit `http://localhost:8000` to see the welcome message.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/vee/main.py
+++ b/vee/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+
+app = FastAPI(title="Vee - Go To Market Platform")
+
+@app.get("/")
+async def root():
+    return {"message": "Welcome to Vee"}
+
+# Placeholder routers for modules
+
+from .modules import product_marketing, sales_enablement, product_management
+
+app.include_router(product_marketing.router, prefix="/marketing", tags=["Product Marketing"])
+app.include_router(sales_enablement.router, prefix="/sales", tags=["Sales Enablement"])
+app.include_router(product_management.router, prefix="/product", tags=["Product Management"])

--- a/vee/modules/product_management.py
+++ b/vee/modules/product_management.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/backlog")
+async def backlog_intelligence():
+    """Placeholder for backlog intelligence."""
+    return {"status": "Backlog insights coming soon"}

--- a/vee/modules/product_marketing.py
+++ b/vee/modules/product_marketing.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/messaging")
+async def generate_messaging():
+    """Placeholder for messaging generator."""
+    return {"status": "Messaging generator coming soon"}

--- a/vee/modules/sales_enablement.py
+++ b/vee/modules/sales_enablement.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+
+router = APIRouter()
+
+@router.get("/playbooks")
+async def get_playbooks():
+    """Placeholder for sales playbooks."""
+    return {"status": "Sales playbooks coming soon"}


### PR DESCRIPTION
## Summary
- add FastAPI skeleton app for Vee
- document placeholder modules
- add `requirements.txt`

## Testing
- `python -m py_compile vee/main.py vee/modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686fdb998270832c9dfa0d13114517b6